### PR TITLE
chore: Change the layout style of the demo from grid to flex.

### DIFF
--- a/apps/example/src/pages/button/examples/disabled.tsx
+++ b/apps/example/src/pages/button/examples/disabled.tsx
@@ -7,61 +7,68 @@ function App() {
   return (
     <div
       style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(3, 100px)',
-        gridRowGap: 24,
-        gridColumnGap: 24,
+        display: 'flex',
+        gap: 16,
       }}
     >
-      <Button type="brand" disabled>
-        Brand
-      </Button>
-      <Button type="outline" disabled>
-        Brand
-      </Button>
-      <Button type="text" disabled>
-        Brand
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" disabled>
+          Brand
+        </Button>
+        <Button type="outline" disabled>
+          Brand
+        </Button>
+        <Button type="text" disabled>
+          Brand
+        </Button>
+      </Space>
 
-      <Button type="brand" status="warning" disabled>
-        Warning
-      </Button>
-      <Button type="outline" status="warning" disabled>
-        Warning
-      </Button>
-      <Button type="text" status="warning" disabled>
-        Warning
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" status="warning" disabled>
+          Warning
+        </Button>
+        <Button type="outline" status="warning" disabled>
+          Warning
+        </Button>
+        <Button type="text" status="warning" disabled>
+          Warning
+        </Button>
+      </Space>
 
-      <Button type="brand" status="error" disabled>
-        Error
-      </Button>
-      <Button type="outline" status="error" disabled>
-        Error
-      </Button>
-      <Button type="text" status="error" disabled>
-        Error
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" status="error" disabled>
+          Error
+        </Button>
+        <Button type="outline" status="error" disabled>
+          Error
+        </Button>
+        <Button type="text" status="error" disabled>
+          Error
+        </Button>
+      </Space>
 
-      <Button type="brand" status="success" disabled>
-        Success
-      </Button>
-      <Button type="outline" status="success" disabled>
-        Success
-      </Button>
-      <Button type="text" status="success" disabled>
-        Success
-      </Button>
-
-      <Button type="brand" status="default" disabled>
-        Default
-      </Button>
-      <Button type="outline" status="default" disabled>
-        Default
-      </Button>
-      <Button type="text" status="default" disabled>
-        Default
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" status="success" disabled>
+          Success
+        </Button>
+        <Button type="outline" status="success" disabled>
+          Success
+        </Button>
+        <Button type="text" status="success" disabled>
+          Success
+        </Button>
+      </Space>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" status="default" disabled>
+          Default
+        </Button>
+        <Button type="outline" status="default" disabled>
+          Default
+        </Button>
+        <Button type="text" status="default" disabled>
+          Default
+        </Button>
+      </Space>
     </div>
   );
 }`;

--- a/apps/example/src/pages/button/examples/group.tsx
+++ b/apps/example/src/pages/button/examples/group.tsx
@@ -8,136 +8,144 @@ function App() {
   return (
     <div
       style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(3, 200px)',
-        gridRowGap: 24,
-        gridColumnGap: 24,
+        display: 'flex',
+        gap: 16,
       }}
     >
-      <ButtonGroup>
-        <Button type="brand">Publish</Button>
-        <Button type="brand" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="outline">Publish</Button>
-        <Button type="outline" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="text">Publish</Button>
-        <Button type="text" icon={<IconArrowBottom />} />
-      </ButtonGroup>
+      <Space direction="vertical" size={16}>
+        <ButtonGroup>
+          <Button type="brand">Publish</Button>
+          <Button type="brand" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="outline">Publish</Button>
+          <Button type="outline" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="text">Publish</Button>
+          <Button type="text" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+      </Space>
 
-      <ButtonGroup>
-        <Button type="brand" status="warning">
-          Publish
-        </Button>
-        <Button type="brand" status="warning" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="outline" status="warning">
-          Publish
-        </Button>
-        <Button type="outline" status="warning" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="text" status="warning">
-          Publish
-        </Button>
-        <Button type="text" status="warning" icon={<IconArrowBottom />} />
-      </ButtonGroup>
+      <Space direction="vertical" size={16}>
+        <ButtonGroup>
+          <Button type="brand" status="warning">
+            Publish
+          </Button>
+          <Button type="brand" status="warning" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="outline" status="warning">
+            Publish
+          </Button>
+          <Button type="outline" status="warning" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="text" status="warning">
+            Publish
+          </Button>
+          <Button type="text" status="warning" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+      </Space>
 
-      <ButtonGroup>
-        <Button type="brand" status="error">
-          Publish
-        </Button>
-        <Button type="brand" status="error" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="outline" status="error">
-          Publish
-        </Button>
-        <Button type="outline" status="error" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="text" status="error">
-          Publish
-        </Button>
-        <Button type="text" status="error" icon={<IconArrowBottom />} />
-      </ButtonGroup>
+      <Space direction="vertical" size={16}>
+        <ButtonGroup>
+          <Button type="brand" status="error">
+            Publish
+          </Button>
+          <Button type="brand" status="error" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="outline" status="error">
+            Publish
+          </Button>
+          <Button type="outline" status="error" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="text" status="error">
+            Publish
+          </Button>
+          <Button type="text" status="error" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+      </Space>
 
-      <ButtonGroup>
-        <Button type="brand" status="success">
-          Publish
-        </Button>
-        <Button type="brand" status="success" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="outline" status="success">
-          Publish
-        </Button>
-        <Button type="outline" status="success" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="text" status="success">
-          Publish
-        </Button>
-        <Button type="text" status="success" icon={<IconArrowBottom />} />
-      </ButtonGroup>
+      <Space direction="vertical" size={16}>
+        <ButtonGroup>
+          <Button type="brand" status="success">
+            Publish
+          </Button>
+          <Button type="brand" status="success" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="outline" status="success">
+            Publish
+          </Button>
+          <Button type="outline" status="success" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="text" status="success">
+            Publish
+          </Button>
+          <Button type="text" status="success" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+      </Space>
 
-      <ButtonGroup>
-        <Button type="brand" status="default">
-          Publish
-        </Button>
-        <Button type="brand" status="default" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="outline" status="default">
-          Publish
-        </Button>
-        <Button type="outline" status="default" icon={<IconArrowBottom />} />
-      </ButtonGroup>
-      <ButtonGroup>
-        <Button type="text" status="default">
-          Publish
-        </Button>
-        <Button type="text" status="default" icon={<IconArrowBottom />} />
-      </ButtonGroup>
+      <Space direction="vertical" size={16}>
+        <ButtonGroup>
+          <Button type="brand" status="default">
+            Publish
+          </Button>
+          <Button type="brand" status="default" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="outline" status="default">
+            Publish
+          </Button>
+          <Button type="outline" status="default" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="text" status="default">
+            Publish
+          </Button>
+          <Button type="text" status="default" icon={<IconArrowBottom />} />
+        </ButtonGroup>
+      </Space>
 
-      <ButtonGroup>
-        <Button type="brand" icon={<IconFavorite />} />
-        <Button type="brand" icon={<IconFabulous />} />
-        <Button type="brand" icon={<IconGood />} />
-      </ButtonGroup>
+      <Space direction="vertical" size={16}>
+        <ButtonGroup>
+          <Button type="brand" icon={<IconFavorite />} />
+          <Button type="brand" icon={<IconFabulous />} />
+          <Button type="brand" icon={<IconGood />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="outline" icon={<IconFavorite />} />
+          <Button type="outline" icon={<IconFabulous />} />
+          <Button type="outline" icon={<IconGood />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button type="text" icon={<IconFavorite />} />
+          <Button type="text" icon={<IconFabulous />} />
+          <Button type="text" icon={<IconGood />} />
+        </ButtonGroup>
+      </Space>
 
-      <ButtonGroup>
-        <Button type="outline" icon={<IconFavorite />} />
-        <Button type="outline" icon={<IconFabulous />} />
-        <Button type="outline" icon={<IconGood />} />
-      </ButtonGroup>
-
-      <ButtonGroup>
-        <Button type="text" icon={<IconFavorite />} />
-        <Button type="text" icon={<IconFabulous />} />
-        <Button type="text" icon={<IconGood />} />
-      </ButtonGroup>
-
-      <ButtonGroup>
-        <Button disabled type="brand" icon={<IconFavorite />} />
-        <Button disabled type="brand" icon={<IconFabulous />} />
-        <Button disabled type="brand" icon={<IconGood />} />
-      </ButtonGroup>
-
-      <ButtonGroup>
-        <Button disabled type="outline" icon={<IconFavorite />} />
-        <Button disabled type="outline" icon={<IconFabulous />} />
-        <Button disabled type="outline" icon={<IconGood />} />
-      </ButtonGroup>
-
-      <ButtonGroup>
-        <Button disabled type="text" icon={<IconFavorite />} />
-        <Button disabled type="text" icon={<IconFabulous />} />
-        <Button disabled type="text" icon={<IconGood />} />
-      </ButtonGroup>
+      <Space direction="vertical" size={16}>
+        <ButtonGroup>
+          <Button disabled type="brand" icon={<IconFavorite />} />
+          <Button disabled type="brand" icon={<IconFabulous />} />
+          <Button disabled type="brand" icon={<IconGood />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button disabled type="outline" icon={<IconFavorite />} />
+          <Button disabled type="outline" icon={<IconFabulous />} />
+          <Button disabled type="outline" icon={<IconGood />} />
+        </ButtonGroup>
+        <ButtonGroup>
+          <Button disabled type="text" icon={<IconFavorite />} />
+          <Button disabled type="text" icon={<IconFabulous />} />
+          <Button disabled type="text" icon={<IconGood />} />
+        </ButtonGroup>
+      </Space>
     </div>
   );
 }`;

--- a/apps/example/src/pages/button/examples/loading.tsx
+++ b/apps/example/src/pages/button/examples/loading.tsx
@@ -1,7 +1,7 @@
 import { Loading } from '../locale';
 
 const code = `
-import { Button } from '@mx-design/web';
+import { Space, Button } from '@mx-design/web';
 
 function App() {
   const [loading1, setLoading1] = React.useState(false);
@@ -23,29 +23,30 @@ function App() {
   return (
     <div
       style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(3, 110px)',
-        rowGap: 24,
-        columnGap: 24,
-        marginLeft: 24,
+        display: 'flex',
+        gap: 16,
       }}
     >
-      <Button type="brand" loading>
-        Loading
-      </Button>
-      <Button type="outline" loading>
-        Loading
-      </Button>
-      <Button type="text" loading>
-        Loading
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" loading>
+          Loading
+        </Button>
+        <Button type="outline" loading>
+          Loading
+        </Button>
+        <Button type="text" loading>
+          Loading
+        </Button>
+      </Space>
 
-      <Button type="brand" loading={loading1} onClick={onClickBtn1}>
-        Click Me
-      </Button>
-      <Button type="brand" loading={loading2} onClick={onClickBtn2}>
-        {!loading2 && <IconAdd />}Click Me
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" loading={loading1} onClick={onClickBtn1}>
+          Click Me
+        </Button>
+        <Button type="brand" loading={loading2} onClick={onClickBtn2}>
+          {!loading2 && <IconAdd />}Click Me
+        </Button>
+      </Space>
     </div>
   );
 }`;

--- a/apps/example/src/pages/button/examples/status.tsx
+++ b/apps/example/src/pages/button/examples/status.tsx
@@ -7,55 +7,63 @@ function App() {
   return (
     <div
       style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(3, 100px)',
-        gridRowGap: 24,
-        gridColumnGap: 24,
+        display: 'flex',
+        gap: 16,
       }}
     >
-      <Button type="brand">Brand</Button>
-      <Button type="outline">Brand</Button>
-      <Button type="text">Brand</Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand">Brand</Button>
+        <Button type="outline">Brand</Button>
+        <Button type="text">Brand</Button>
+      </Space>
 
-      <Button type="brand" status="warning">
-        Warning
-      </Button>
-      <Button type="outline" status="warning">
-        Warning
-      </Button>
-      <Button type="text" status="warning">
-        Warning
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" status="warning">
+          Warning
+        </Button>
+        <Button type="outline" status="warning">
+          Warning
+        </Button>
+        <Button type="text" status="warning">
+          Warning
+        </Button>
+      </Space>
 
-      <Button type="brand" status="error">
-        Error
-      </Button>
-      <Button type="outline" status="error">
-        Error
-      </Button>
-      <Button type="text" status="error">
-        Error
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" status="error">
+          Error
+        </Button>
+        <Button type="outline" status="error">
+          Error
+        </Button>
+        <Button type="text" status="error">
+          Error
+        </Button>
+      </Space>
 
-      <Button type="brand" status="success">
-        Success
-      </Button>
-      <Button type="outline" status="success">
-        Success
-      </Button>
-      <Button type="text" status="success">
-        Success
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" status="success">
+          Success
+        </Button>
+        <Button type="outline" status="success">
+          Success
+        </Button>
+        <Button type="text" status="success">
+          Success
+        </Button>
+      </Space>
 
-      <Button type="brand" status="default">
-        Default
-      </Button>
-      <Button type="outline" status="default">
-        Default
-      </Button>
-      <Button type="text" status="default">
-        Default
-      </Button>
+      <Space direction="vertical" size={16}>
+        <Button type="brand" status="default">
+          Default
+        </Button>
+        <Button type="outline" status="default">
+          Default
+        </Button>
+        <Button type="text" status="default">
+          Default
+        </Button>
+      </Space>
     </div>
   );
 }`;


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [x] 其他改动（日常 bugfix、文档、站点改进、分支合并等）

### 背景
  
> 1. 运行此项目，查看`Button`组件时，部分使用`grid`布局的演示`demo`会出现**样式异常**
![image](https://github.com/lio-mengxiang/mx-design/assets/47563372/07b1e421-b66f-4e4c-9334-49178ebe437e)
 当用户输入过长的文本，则文本内容会超出`Button`组件，对用户的使用体验造成不太好的影响。



### 实现方案
  
> 1. 向业界一流的组件库`antd`学习了一波，使用`flex`布局替换`grid`布局，并且讨论后得出更优雅的解法，竖向布局保证一定程度的对齐，**提升了美观性**。
![image](https://github.com/lio-mengxiang/mx-design/assets/47563372/d0b28d6e-5b26-4f47-ae71-7c688ddf3303)
![image](https://github.com/lio-mengxiang/mx-design/assets/47563372/2a646ca2-87a0-4b7b-850a-aa5755e0ef7a)



### 请求合并前的自查清单

- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
